### PR TITLE
fix(Patient Appointment): rearrange method get_appointment_billing_item_and_rate

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -455,14 +455,14 @@ def get_appointment_billing_item_and_rate(doc):
 
 	is_inpatient = doc.inpatient_record
 
-	if doc.get("practitioner"):
-		service_item, practitioner_charge = get_practitioner_billing_details(
-			doc.practitioner, is_inpatient
+	if doc.get("appointment_type"):
+		service_item, practitioner_charge = get_appointment_type_billing_details(
+			doc.appointment_type, department if department else service_unit, is_inpatient
 		)
 
-	if not service_item and doc.get("appointment_type"):
-		service_item, appointment_charge = get_appointment_type_billing_details(
-			doc.appointment_type, department if department else service_unit, is_inpatient
+	if not service_item and doc.get("practitioner"):
+		service_item, appointment_charge = get_practitioner_billing_details(
+			doc.practitioner, is_inpatient
 		)
 		if not practitioner_charge:
 			practitioner_charge = appointment_charge

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -7,6 +7,7 @@ healthcare.patches.v15_0.create_custom_fields_in_sales_invoice_item
 healthcare.patches.v15_0.rename_automate_appointment_invoicing
 healthcare.patches.v15_0.rename_medical_code_standard_and_medical_code
 healthcare.patches.v15_0.setup_service_request
+healthcare.patches.v15_0.create_custom_field_in_payment_entry
 
 [post_model_sync]
 healthcare.patches.v15_0.rename_field_medical_department_in_appoitment_type_service_item

--- a/healthcare/patches/v15_0/create_custom_field_in_payment_entry.py
+++ b/healthcare/patches/v15_0/create_custom_field_in_payment_entry.py
@@ -1,0 +1,18 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	custom_field = {
+		"Payment Entry": [
+			{
+				"fieldname": "treatment_counselling",
+				"label": "Treatment Counselling",
+				"fieldtype": "Link",
+				"options": "Treatment Counselling",
+				"insert_after": "payment_order",
+				"read_only": True,
+			},
+		]
+	}
+
+	create_custom_fields(custom_field)


### PR DESCRIPTION
Issue No. 296:

According to documentation the charges set on the appointment type should override the charges set at practitioner level.

Docs Link:
https://frappehealth.com/patient-appointment#:~:text=If%20the%20Appointment,the%20above%20configuration.

However, the system was still applying the practitioner charges while expected behaviour is to apply appointment type charges.
<img width="805" alt="278662539-c3831eb9-88c6-4843-8ba4-37a6895ac5d6" src="https://github.com/user-attachments/assets/8576af1d-a02b-4f91-a288-5a648c50975d">

<img width="955" alt="278660000-ea4e0c53-7c37-489e-bb79-1b99cb8ccd92" src="https://github.com/user-attachments/assets/773c77d1-58a0-4a8d-ae7e-6880cac3e0e1">
